### PR TITLE
DOP-1750 tag with kustomize

### DIFF
--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -47,6 +47,15 @@ inputs:
     description: path for image layer cache; do not change this value. Used to reduce repitition
     required: false
     default: /tmp/.buildx-cache
+
+outputs:
+  image-name-short: ${{ steps.generate-tags.outputs.image-name-short }}
+
+  image-name-medium: ${{ steps.generate-tags.outputs.image-name-medium }}
+  
+  image-name-long: ${{ steps.generate-tags.outputs.image-name-long }}
+
+
 runs:
   using: composite
   steps:
@@ -100,7 +109,19 @@ runs:
       with:
         format: 'YYYY-MM-DD-HH-mm-ss'
 
+    - name: Generate Tags
+      id: generate-tags
+      shell: bash
+      run: |
+          IMAGE_NAME_SHORT="${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ steps.short-sha.outputs.sha }}"
+          IMAGE_NAME_MEDIUM="${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ steps.short-sha.outputs.sha }}-${{ github.run_number }}"
+          IMAGE_NAME_LONG="${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ steps.short-sha.outputs.sha }}-${{ github.run_number }}-${{ steps.time.outputs.time }}"
+          echo "::set-output name=image-name-short::$IMAGE_NAME_SHORT"
+          echo "::set-output name=image-name-short::$IMAGE_NAME_MEDIUM"
+          echo "::set-output name=image-name-short::$IMAGE_NAME_LONG"
+
     - name: Build and push Docker image
+      id: build-push
       uses: docker/build-push-action@v2.7.0
       env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -113,9 +134,9 @@ runs:
         network: host
         push: ${{ inputs.push-to-ecr }}
         tags: |
-          ${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ steps.short-sha.outputs.sha }}
-          ${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ steps.short-sha.outputs.sha }}-${{ github.run_number }}
-          ${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ steps.short-sha.outputs.sha }}-${{ github.run_number }}-${{ steps.time.outputs.time }}
+          ${{ steps.generate-tags.outputs.image-name-short }}
+          ${{ steps.generate-tags.outputs.image-name-medium }}
+          ${{ steps.generate-tags.outputs.image-name-long }}
           ${{ steps.prepend-tags.outputs.replaced }}
         # layer cache settings
         cache-from: type=local,src=${{ inputs.layer-cache-path }}

--- a/composite/kustomize-set-image/action.yml
+++ b/composite/kustomize-set-image/action.yml
@@ -1,0 +1,71 @@
+name: Kustomize Set Image Tag
+description: Patches a new image tag into a kubernetes project via 'kustomize edit image'
+
+inputs:
+  github-token:
+    description: Github token with permissions to push commits to the given manifests-repository
+    required: true
+  
+  github-user-name:
+    description: Github user name to associate with automated commits from this workflow
+    required: false
+    default: kustomize-github-workflow
+
+  github-user-email:
+    description: Github user email to associate with automated commits from this workflow
+    required: false
+    default: build.vela.care
+
+  manifests-repository:
+    description: Github repository containing deployment manifests to kustomize
+    required: true
+
+  manifests-ref:
+    description: Github reference to a commit or branch where kustomize will push changes
+    required: true
+    
+  manifests-path:
+    description: Relative path to the directory containing the desired kustomization file to modify within the manifests-repository
+    required: true
+  
+  image:
+    description: The fully-qualified image name to pin via kustomize
+    required: true
+    
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ manifests-repository }}
+        ref: ${{ manifests-ref }}
+        token: ${{ github-token }}
+
+    - name: Setup Kustomize
+      id: setup-kustomize
+      uses: imranismail/setup-kustomize@v1
+
+    - name: Kustomize Image Tag
+      id: kustomize-image-tag
+      shell: bash
+      run: |
+        cd ${{ manifests-path }}
+        kustomize edit set image ${{ image }}
+    
+    - name: Set Git user and email
+      id: set-git-identity
+      shell: bash
+      run: |
+        git config --global user.email "${{ github-user-email }}"
+        git config --global user.name "${{ github-user-name }}"
+
+    - name: Push to SCM repository
+      id: push-to-scm
+      shell: bash
+      run: |
+        git checkout -b kustomize-test-branch
+        echo '--------------------------'
+        git commit -am 'automation: kustomize set image for '
+        echo '--------------------------'
+        git push --set-upstream origin HEAD


### PR DESCRIPTION
This change currently pushes kustomizations to a separate branch instead of main.  If the PR looks good, I'll commit as-is for testing.  Once testing completes, I'll change this workflow to commit directly to main

- a0db459 -  separate generation of tag names and output them
- 7c8f305 - adding new kustomize composite