### PR TITLE
DOP-1702 build metadata for k8s

### DIFF
--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -19,8 +19,8 @@ inputs:
     description: aws access key secret - use a github secret
     required: true
 
-  github-token:
-    description: github token used to access 
+  build-secrets:
+    description: string formatted list of buildkit secrets to use in the build - use github secrets
     required: false
     default: ""
 
@@ -139,7 +139,6 @@ runs:
           type=semver,pattern={{version}}
         labels: |
           org.opencontainers.image.revision=apple${{ steps.short-sha.outputs.sha }}
-        # github-token: ${{ inputs.github-token }}
 
     - name: Build and push Docker image
       id: build-push
@@ -149,7 +148,7 @@ runs:
       with:
         context: ${{ inputs.dockerfile-context-path }}
         secrets: |
-          github_token=${{ inputs.github-token }}
+          ${{ inputs.build-secrets }}
         target: ${{ inputs.dockerfile-target }}
         # allows the build to communicate with GH services as localhost
         network: host

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -126,6 +126,19 @@ runs:
           echo "::set-output name=image-name-medium::$IMAGE_NAME_MEDIUM"
           echo "::set-output name=image-name-long::$IMAGE_NAME_LONG"
 
+    - name: Docker meta
+      id: docker-meta
+      uses: docker/metadata-action@v3
+      with:
+        # generate Docker tags based on the following events/attributes
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha,prefix=
+
     - name: Build and push Docker image
       id: build-push
       uses: docker/build-push-action@v2.7.0
@@ -144,6 +157,9 @@ runs:
           ${{ steps.generate-tags.outputs.image-name-medium }}
           ${{ steps.generate-tags.outputs.image-name-long }}
           ${{ steps.prepend-tags.outputs.replaced }}
+          ${{ steps.docker-meta.outputs.tags }}
+        labels: |
+          ${{ steps.docker-meta.outputs.labels }}
         # layer cache settings
         cache-from: type=local,src=${{ inputs.layer-cache-path }}
         cache-to: type=local,dest=${{ inputs.layer-cache-path }}-new,mode=max

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -141,8 +141,7 @@ runs:
           type=sha,prefix=,suffix=-${{ github.run_number }}
           type=sha,prefix=,suffix=-${{ github.run_number }}-${{ steps.time.outputs.time }}
         labels: |
-          org.opencontainers.image.revision="${{ steps.short-sha.outputs.sha }}"
-          org.opencontainers.image.commit_msg="${{ github.event.head_commit.message }}"
+          org.opencontainers.image.revision=${{ steps.short-sha.outputs.sha }}
         github-token: ${{ inputs.github-token }}
 
     - name: Build and push Docker image

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -139,7 +139,6 @@ runs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-          type=sha,prefix=
         github-token: ${{ inputs.github-token }}
 
     - name: Build and push Docker image

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -47,6 +47,11 @@ inputs:
     description: path for image layer cache; do not change this value. Used to reduce repitition
     required: false
     default: /tmp/.buildx-cache
+  
+  comment:
+    description: Commit message to add to image metadata under OCI label 
+    required: false
+    default: ""
 
 outputs:
   image-name-short:
@@ -135,8 +140,13 @@ runs:
         # generate Docker tags based on the following events/attributes
         tags: |
           type=ref,event=branch
+          type=ref,event=pr
           type=semver,pattern=v{{version}}
           type=sha,prefix=
+        labels: |
+          org.opencontainers.image.revision=${{ steps.short-sha.outputs.sha }}
+          org.opencontainers.image.commit_comment1=${{ inputs.comment }}
+          org.opencontainers.image.commit_comment2=${{ github.event.head_commit.message }}
         github-token: ${{ inputs.github-token }}
 
     - name: Build and push Docker image
@@ -153,10 +163,6 @@ runs:
         network: host
         push: ${{ inputs.push-to-ecr }}
         tags: |
-          ${{ steps.generate-tags.outputs.image-name-short }}
-          ${{ steps.generate-tags.outputs.image-name-medium }}
-          ${{ steps.generate-tags.outputs.image-name-long }}
-          ${{ steps.prepend-tags.outputs.replaced }}
           ${{ steps.docker-meta.outputs.tags }}
         labels: |
           ${{ steps.docker-meta.outputs.labels }}
@@ -174,3 +180,8 @@ runs:
         if [[ -d ${{ inputs.layer-cache-path }}-new  ]]; then
           mv ${{ inputs.layer-cache-path }}-new ${{ inputs.layer-cache-path }}
         fi
+
+# ${{ steps.generate-tags.outputs.image-name-short }}
+#           ${{ steps.generate-tags.outputs.image-name-medium }}
+#           ${{ steps.generate-tags.outputs.image-name-long }}
+#           ${{ steps.prepend-tags.outputs.replaced }}

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -130,6 +130,8 @@ runs:
       id: docker-meta
       uses: docker/metadata-action@v3
       with:
+        # Base image name for tags (required)
+        images: name/app
         # generate Docker tags based on the following events/attributes
         tags: |
           type=ref,event=branch

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -47,11 +47,6 @@ inputs:
     description: path for image layer cache; do not change this value. Used to reduce repitition
     required: false
     default: /tmp/.buildx-cache
-  
-  comment:
-    description: Commit message to add to image metadata under OCI label 
-    required: false
-    default: ""
 
 outputs:
   image-name-short:
@@ -139,14 +134,13 @@ runs:
         images: "${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repository }}"
         # generate Docker tags based on the following events/attributes
         tags: |
-          type=ref,event=branch
-          type=ref,event=pr
           type=semver,pattern=v{{version}}
           type=sha,prefix=
+          type=sha,prefix=,suffix="-${{ github.run_number }}"
+          type=sha,prefix=,suffix="-${{ github.run_number }}-${{ steps.time.outputs.time }}"
         labels: |
           org.opencontainers.image.revision=${{ steps.short-sha.outputs.sha }}
-          org.opencontainers.image.commit_comment1=${{ inputs.comment }}
-          org.opencontainers.image.commit_comment2=${{ github.event.head_commit.message }}
+          org.opencontainers.image.commit_msg=${{ github.event.head_commit.message }}
         github-token: ${{ inputs.github-token }}
 
     - name: Build and push Docker image
@@ -180,8 +174,3 @@ runs:
         if [[ -d ${{ inputs.layer-cache-path }}-new  ]]; then
           mv ${{ inputs.layer-cache-path }}-new ${{ inputs.layer-cache-path }}
         fi
-
-# ${{ steps.generate-tags.outputs.image-name-short }}
-#           ${{ steps.generate-tags.outputs.image-name-medium }}
-#           ${{ steps.generate-tags.outputs.image-name-long }}
-#           ${{ steps.prepend-tags.outputs.replaced }}

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -135,10 +135,8 @@ runs:
         # generate Docker tags based on the following events/attributes
         tags: |
           type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
+          type=semver,pattern=v{{version}}
+          type=sha,prefix=
         github-token: ${{ inputs.github-token }}
 
     - name: Build and push Docker image

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -131,7 +131,7 @@ runs:
       uses: docker/metadata-action@v3
       with:
         # Base image name for tags (required)
-        images: ${{ inputs.ecr-repository }}
+        images: "${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repository }}"
         # generate Docker tags based on the following events/attributes
         tags: |
           type=ref,event=branch

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: true
 
   github-token:
-    description: string formatted list of buildkit secrets to use in the build - use github secrets
+    description: github token used to access 
     required: false
     default: ""
 
@@ -136,13 +136,10 @@ runs:
         tags: |
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern=v{{version}}
-          type=sha,prefix=
-          type=sha,prefix=,suffix=-${{ github.run_number }}
-          type=sha,prefix=,suffix=-${{ github.run_number }}-${{ steps.time.outputs.time }}
+          type=semver,pattern={{version}}
         labels: |
           org.opencontainers.image.revision=${{ steps.short-sha.outputs.sha }}
-        github-token: ${{ inputs.github-token }}
+        # github-token: ${{ inputs.github-token }}
 
     - name: Build and push Docker image
       id: build-push
@@ -158,6 +155,10 @@ runs:
         network: host
         push: ${{ inputs.push-to-ecr }}
         tags: |
+          ${{ steps.generate-tags.outputs.image-name-short }}
+          ${{ steps.generate-tags.outputs.image-name-medium }}
+          ${{ steps.generate-tags.outputs.image-name-long }}
+          ${{ steps.prepend-tags.outputs.replaced }}
           ${{ steps.docker-meta.outputs.tags }}
         labels: |
           ${{ steps.docker-meta.outputs.labels }}

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -138,7 +138,7 @@ runs:
           type=ref,event=pr
           type=semver,pattern={{version}}
         labels: |
-          org.opencontainers.image.revision=${{ steps.short-sha.outputs.sha }}
+          org.opencontainers.image.revision=apple${{ steps.short-sha.outputs.sha }}
         # github-token: ${{ inputs.github-token }}
 
     - name: Build and push Docker image

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -134,13 +134,15 @@ runs:
         images: "${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repository }}"
         # generate Docker tags based on the following events/attributes
         tags: |
+          type=ref,event=branch
+          type=ref,event=pr
           type=semver,pattern=v{{version}}
           type=sha,prefix=
           type=sha,prefix=,suffix=-${{ github.run_number }}
           type=sha,prefix=,suffix=-${{ github.run_number }}-${{ steps.time.outputs.time }}
         labels: |
-          org.opencontainers.image.revision=${{ steps.short-sha.outputs.sha }}
-          org.opencontainers.image.commit_msg=${{ github.event.head_commit.message }}
+          org.opencontainers.image.revision="${{ steps.short-sha.outputs.sha }}"
+          org.opencontainers.image.commit_msg="${{ github.event.head_commit.message }}"
         github-token: ${{ inputs.github-token }}
 
     - name: Build and push Docker image

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -138,7 +138,7 @@ runs:
           type=ref,event=pr
           type=semver,pattern={{version}}
         labels: |
-          org.opencontainers.image.revision=apple${{ steps.short-sha.outputs.sha }}
+          org.opencontainers.image.revision=${{ steps.short-sha.outputs.sha }}
 
     - name: Build and push Docker image
       id: build-push

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -136,8 +136,8 @@ runs:
         tags: |
           type=semver,pattern=v{{version}}
           type=sha,prefix=
-          type=sha,prefix=,suffix="-${{ github.run_number }}"
-          type=sha,prefix=,suffix="-${{ github.run_number }}-${{ steps.time.outputs.time }}"
+          type=sha,prefix=,suffix=-${{ github.run_number }}
+          type=sha,prefix=,suffix=-${{ github.run_number }}-${{ steps.time.outputs.time }}
         labels: |
           org.opencontainers.image.revision=${{ steps.short-sha.outputs.sha }}
           org.opencontainers.image.commit_msg=${{ github.event.head_commit.message }}

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -131,7 +131,7 @@ runs:
       uses: docker/metadata-action@v3
       with:
         # Base image name for tags (required)
-        images: name/app
+        images: ${{ inputs.ecr-repository }}
         # generate Docker tags based on the following events/attributes
         tags: |
           type=ref,event=branch

--- a/composite/docker-build/action.yml
+++ b/composite/docker-build/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: aws access key secret - use a github secret
     required: true
 
-  build-secrets:
+  github-token:
     description: string formatted list of buildkit secrets to use in the build - use github secrets
     required: false
     default: ""
@@ -140,6 +140,7 @@ runs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
           type=sha,prefix=
+        github-token: ${{ inputs.github-token }}
 
     - name: Build and push Docker image
       id: build-push
@@ -149,7 +150,7 @@ runs:
       with:
         context: ${{ inputs.dockerfile-context-path }}
         secrets: |
-          ${{ inputs.build-secrets }}
+          github_token=${{ inputs.github-token }}
         target: ${{ inputs.dockerfile-target }}
         # allows the build to communicate with GH services as localhost
         network: host


### PR DESCRIPTION
Adding automatic generation of tags and labels to ecr images during the github build and push.

**Commits**
- 48759b8 - dont need to change build-secrets
- 6fd8ab8 - try: change to token
- 7be8a5b - cleaning up
- 2252814 - commit msgs dont work well
- bd37f2c - must quote generic string data
- 8e95194 - fixing quotes
- 1e21a85 - updating tags and labels
- 7d6e5ff - wip: testing addl labels and tags
- 15b7b3a - modifying tag generation rules
- 0f1997d - add registry to base image specifier
- e95d556 - remove custom tags for now
- 1b0f3ac - input should be github token
- d2f4d26 - image name not automatically detected
- e91de7a - base image name required
- 7053e73 - try: first set of tags and labels